### PR TITLE
Fix typo, rename method

### DIFF
--- a/common.go
+++ b/common.go
@@ -39,7 +39,7 @@ type Config[T any] map[string]map[string]T
 // Get returns the config value for the given request.
 func (c Config[T]) Get(path string) (v T, err error) {
 	if c == nil {
-		return v, fmt.Errorf("cofig is nil")
+		return v, fmt.Errorf("config is nil")
 	}
 
 	p := strings.Split(path, "/")
@@ -65,13 +65,13 @@ func (c Config[T]) Get(path string) (v T, err error) {
 	return v, nil
 }
 
-// VerifyACL checks that the given ACL config is valid for the given service.
+// Verify checks that the given config is valid for the given service.
 // It can be used in unit tests to ensure that all methods are covered.
-func (acl Config[any]) VerifyACL(webrpcServices map[string][]string) error {
+func (c Config[any]) Verify(webrpcServices map[string][]string) error {
 	var errList []error
 	for service, methods := range webrpcServices {
 		for _, method := range methods {
-			if _, ok := acl[service][method]; !ok {
+			if _, ok := c[service][method]; !ok {
 				errList = append(errList, fmt.Errorf("%s.%s not found", service, method))
 			}
 		}

--- a/common_test.go
+++ b/common_test.go
@@ -47,7 +47,7 @@ func executeRequest(t *testing.T, ctx context.Context, handler http.Handler, pat
 	return true, nil
 }
 
-func TestVerifyACL(t *testing.T) {
+func TestVerify(t *testing.T) {
 	services := map[string][]string{
 		"Service1": {
 			"Method1",
@@ -71,7 +71,7 @@ func TestVerifyACL(t *testing.T) {
 		},
 	}
 
-	err := acl.VerifyACL(services)
+	err := acl.Verify(services)
 	assert.NoError(t, err)
 
 	// Wrong Service
@@ -86,7 +86,7 @@ func TestVerifyACL(t *testing.T) {
 		},
 	}
 
-	err = acl.VerifyACL(services)
+	err = acl.Verify(services)
 	require.Error(t, err)
 
 	expectedErrors := []error{
@@ -106,7 +106,7 @@ func TestVerifyACL(t *testing.T) {
 		},
 	}
 
-	err = acl.VerifyACL(services)
+	err = acl.Verify(services)
 	require.Error(t, err)
 
 	expectedErrors = []error{


### PR DESCRIPTION
Rename function, since it's generic and not for ACL