### PR TITLE
Support both project JWT claims

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -1,6 +1,7 @@
 package authcontrol
 
 import (
+	"cmp"
 	"errors"
 	"net/http"
 	"strings"
@@ -101,7 +102,8 @@ func Session(cfg Options) func(next http.Handler) http.Handler {
 				serviceClaim, _ := claims["service"].(string)
 				accountClaim, _ := claims["account"].(string)
 				adminClaim, _ := claims["admin"].(bool)
-				projectClaim, _ := claims["project"].(float64)
+				// TODO: we support both claims for now, we'll eventually deprecate one.
+				projectClaim, _ := cmp.Or(claims["project"], claims["project_id"]).(float64)
 
 				switch {
 				case serviceClaim != "":

--- a/middleware.go
+++ b/middleware.go
@@ -102,7 +102,9 @@ func Session(cfg Options) func(next http.Handler) http.Handler {
 				serviceClaim, _ := claims["service"].(string)
 				accountClaim, _ := claims["account"].(string)
 				adminClaim, _ := claims["admin"].(bool)
-				// TODO: we support both claims for now, we'll eventually deprecate one.
+				// We support both claims for now, we'll deprecate one if we can.
+				// - `project` is used by the builder to generate Project JWT tokens.
+				// - `project_id` is used by API for WaaS related authentication.
 				projectClaim, _ := cmp.Or(claims["project"], claims["project_id"]).(float64)
 
 				switch {

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -66,7 +66,7 @@ func TestSession(t *testing.T) {
 	}}
 
 	const (
-		AccessKey     = "AQAAAAAAAAAHkL0mNSrn6Sm3oHs0xfa_DnY"
+		AccessKey     = "abcde12345"
 		WalletAddress = "walletAddress"
 		UserAddress   = "userAddress"
 		AdminAddress  = "adminAddress"
@@ -191,7 +191,7 @@ func TestInvalid(t *testing.T) {
 	}
 
 	const (
-		AccessKey     = "AQAAAAAAAAAHkL0mNSrn6Sm3oHs0xfa_DnY"
+		AccessKey     = "abcde12345"
 		WalletAddress = "walletAddress"
 		UserAddress   = "userAddress"
 		AdminAddress  = "adminAddress"
@@ -283,10 +283,10 @@ func TestInvalid(t *testing.T) {
 	assert.ErrorIs(t, err, proto.ErrSessionExpired)
 
 	// Invalid Project
-	wrongProject := authcontrol.S2SToken(JWTSecret, map[string]any{"account": WalletAddress, "project": ProjectID + 1})
+	wrongProject := authcontrol.S2SToken(JWTSecret, map[string]any{"account": WalletAddress, "project_id": ProjectID + 1})
 	ok, err = executeRequest(t, ctx, r, fmt.Sprintf("/rpc/%s/%s", ServiceName, MethodName), jwt(wrongProject))
-	assert.Error(t, err)
 	assert.False(t, ok)
+	assert.ErrorIs(t, err, proto.ErrProjectNotFound)
 }
 
 func TestCustomErrHandler(t *testing.T) {
@@ -305,7 +305,7 @@ func TestCustomErrHandler(t *testing.T) {
 	}
 
 	const (
-		AccessKey    = "AQAAAAAAAAAHkL0mNSrn6Sm3oHs0xfa_DnY"
+		AccessKey    = "abcde12345"
 		UserAddress  = "userAddress"
 		AdminAddress = "adminAddress"
 	)


### PR DESCRIPTION
We support both `project` and `project_id` claims for now.