### PR TITLE
Propagate Access Key

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -158,7 +158,7 @@ func Session(cfg Options) func(next http.Handler) http.Handler {
 				}
 			}
 
-			if accessKey != "" && sessionType < proto.SessionType_Admin {
+			if accessKey != "" {
 				ctx = WithAccessKey(ctx, accessKey)
 				sessionType = max(sessionType, proto.SessionType_AccessKey)
 			}

--- a/middleware.go
+++ b/middleware.go
@@ -199,6 +199,7 @@ func AccessControl(acl Config[ACL], cfg Options) func(next http.Handler) http.Ha
 }
 
 // PropagateAccessKey propagates the access key from the context to other webrpc packages.
+// It expectes the function `WithHTTPRequestHeaders` from the proto package that requires the access key propogation.
 func PropagateAccessKey(headerContextFuncs ...func(context.Context, http.Header) (context.Context, error)) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Always set access key in the context.

Middleware to propagate it to other packages.