### PR TITLE
Restrict CORS access for Builder Secret Keys

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -223,9 +223,8 @@ func Session(cfg Options) func(next http.Handler) http.Handler {
 							slog.Uint64("project_id", uint64(projectClaim)),
 						)
 
-						// TODO: Uncomment once we're confident it won't disrupt major customers.
-						// cfg.ErrHandler(r, w, err)
-						// return
+						cfg.ErrHandler(r, w, err)
+						return
 					}
 				}
 			}
@@ -271,7 +270,7 @@ func AccessControl(acl Config[ACL], cfg Options) func(next http.Handler) http.Ha
 }
 
 // PropagateAccessKey propagates the access key from the context to other webrpc packages.
-// It expectes the function `WithHTTPRequestHeaders` from the proto package that requires the access key propogation.
+// It expects the function `WithHTTPRequestHeaders` from the proto package that requires the access key propogation.
 func PropagateAccessKey(headerContextFuncs ...func(context.Context, http.Header) (context.Context, error)) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
I don't see any more "CORS disallowed" errors in the Logs. So, let's error out for real now.
- [PROD logs](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.cluster_name%3D%22sequence-ceb2b44%22%0Aresource.labels.location%3D%22us-central1%22%0A%22CORS%20disallowed%22;cursorTimestamp=2025-03-08T19:07:53.219233417Z;duration=P2D?inv=1&invt=Abrggw&project=sequence-gke-prod)
- [DEV logs](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.cluster_name%3D%22sequence-b27697b%22%0Aresource.labels.namespace_name%3D%22dev-sequence%22%0A%22CORS%20disallowed%20for%20Secret%20Key%22;cursorTimestamp=2025-03-08T19:03:13.170973065Z;duration=P7D?inv=1&invt=AbrgiQ&project=sequence-gke-dev)

 

Fixes https://github.com/0xsequence/issue-tracker/issues/3787